### PR TITLE
feat: adopt harmony prompt format

### DIFF
--- a/test.js
+++ b/test.js
@@ -12,39 +12,41 @@ function askLLaMA( { prompt, tokens = 1024, base = (basePrompt + serverAwareness
     let data = {
         messages: [
             {
-                content: base,
-                role: 'system'
+                role: 'system',
+                content: [ { type: 'text', text: base } ]
             }
         ],
-        n_predict: 256
+        max_output_tokens: tokens,
+        reasoning: { effort: 'light' }
     };
 
     //prompt is an array of messages, add each individually
     prompt.forEach( msg => {
         if ( msg.isBot ) {
             data.messages.push( {
-                content: msg.content,
-                role: 'assistant'
+                role: 'assistant',
+                content: [ { type: 'text', text: msg.content } ]
             } );
         } else {
             data.messages.push( {
-                content: `${ msg.sender } (${ new Date( msg.timestamp ).toLocaleString( 'en-US', timeStringOptions ) }): ${ msg.content }`,
-                role: 'user'
+                role: 'user',
+                content: [ { type: 'text', text: `${ msg.sender } (${ new Date( msg.timestamp ).toLocaleString( 'en-US', timeStringOptions ) }): ${ msg.content }` } ]
             } );
         }
     } );
     // Add a prompt to get it to output something coherent
     data.messages.push( {
-        content: `The preceding messages (with added timestamps and usernames) are part of a conversation on a discord server that you are on. 
-        Your full response will be sent back a single message to the server. 
+        role: 'user',
+        content: [ { type: 'text', text: `The preceding messages (with added timestamps and usernames) are part of a conversation on a discord server that you are on.
+        Your full response will be sent back a single message to the server.
         Everyone knows who you are; you do not need to introduce yourself.
         Don't speak for anyone else, be yourself!
-        Please respond with a single message AS YOURSELF to answer any questions and/or contribute to the conversation.`,
-        role: 'user'
+        Please respond with a single message AS YOURSELF to answer any questions and/or contribute to the conversation.` } ]
     } );
 
     axios.post( "https://dev.aqanta.com/v1/chat/completions", data ).then( result => {
-        console.log( result.data.choices[0].message.content );
+        const text = result.data?.choices?.[0]?.message?.content?.[0]?.text || '';
+        console.log( text );
     } ).catch( err => {
         console.log( err );
     } );


### PR DESCRIPTION
## Summary
- switch chat payload to harmony `messages` format
- enable light reasoning for all requests
- parse text from updated OpenAI response schema

## Testing
- `node --check helperFunctions.js`
- `node --check test.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893c07e1d68832f9a2a9ae917cff1e1