### PR TITLE
Add unit tests for bot message handling and options

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,14 +78,17 @@ Examples:
 
 setBasePrompt();
 
-const { token } = require( './config.json' );
+let token;
+if ( require.main === module ) {
+    ( { token } = require( './config.json' ) );
+}
 const { get } = require( "axios" );
 
 client.on( 'ready', () => {
     console.log( `Logged in as ${ client.user.tag }!` );
 } );
 
-client.on( 'messageCreate', msg => {
+function handleMessage( msg ) {
 
     // don't self reply, ever
     if ( msg.author.bot ) {
@@ -265,9 +268,9 @@ client.on( 'messageCreate', msg => {
             return;
         }
     }
-} );
+}
 
-client.login( token );
+client.on( 'messageCreate', handleMessage );
 
 function getPastMessages( channel, count, timestamp, callback ) {
     channel.messages.fetch( { limit: count } ) // Adjust limit if you need to fetch more than 100 messages
@@ -300,4 +303,9 @@ async function setUpInspire() {
     setNextInspirationalMessage( await client.channels.fetch( '705154122617323601' ) );
 }
 
-setUpInspire();
+if ( require.main === module ) {
+    client.login( token );
+    setUpInspire();
+}
+
+module.exports = { handleMessage, setBasePrompt, personalities, client };

--- a/helperFunctions.js
+++ b/helperFunctions.js
@@ -13,7 +13,7 @@ function sendOutput( msg, send ) {
     if ( msg.length > 2000 ) {
         while ( msg.length > 2000 ) {
             send( msg.slice( 0, 1800 ) );
-            msg = msg.slice( 1800, -1 );
+            msg = msg.slice( 1800 );
         }
     }
     try {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "node --test tests"
+  },
   "dependencies": {
     "axios": "^1.4.0",
     "colors": "^1.4.0",

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,48 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { sendOutput } = require('../helperFunctions');
+const { handleMessage, client } = require('../app');
+const { SETTINGS } = require('../settings');
+
+test('sendOutput splits long messages', () => {
+  const outputs = [];
+  sendOutput('a'.repeat(4000), msg => outputs.push(msg));
+  assert(outputs.length > 1);
+  assert.strictEqual(outputs.join('').length, 4000);
+  outputs.forEach(o => assert(o.length <= 2000));
+});
+
+test('handleMessage ignores messages from bots', () => {
+  const msg = { author: { bot: true } };
+  const result = handleMessage(msg);
+  assert.strictEqual(result, false);
+});
+
+test('handleMessage can change personality', () => {
+  const reactions = [];
+  const msg = {
+    author: { bot: false },
+    content: '?llamaPersonality sigma',
+    react: emoji => reactions.push(emoji)
+  };
+  handleMessage(msg);
+  assert.strictEqual(SETTINGS.personality, 'sigma');
+  assert.deepStrictEqual(reactions, ['👍']);
+});
+
+test('handleMessage responds to ?llamaOptions list', () => {
+  const replies = [];
+  client.user = { id: '1' };
+  const msg = {
+    author: { bot: false },
+    guild: {},
+    content: '?llamaOptions list',
+    react: () => {},
+    reply: text => replies.push(text)
+  };
+  handleMessage(msg);
+  assert.strictEqual(replies.length, 1);
+  const obj = JSON.parse(replies[0]);
+  assert.ok(Object.prototype.hasOwnProperty.call(obj, 'defaultTokens'));
+});


### PR DESCRIPTION
## Summary
- export Discord message handler to enable unit tests and guard login behind `require.main`
- preserve full content when splitting long messages
- add tests covering message limits, bot self-talk, personality changes, and `?llamaOptions`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893c2e71864832f9b00f4126f933101