### PR TITLE
Fix message history handling and strip analysis output

### DIFF
--- a/app.js
+++ b/app.js
@@ -125,7 +125,7 @@ function handleMessage( msg ) {
     if ( !msg.guild ) {
         const twelveHoursAgo = Date.now() - 12 * 60 * 60 * 1000;
         getPastMessages( msg.channel, 5, twelveHoursAgo, messageHistory => {
-            askLLaMA( { prompt: messageHistory + "\n[Bot]", tokens: SETTINGS.defaultTokens }, ( result ) => {
+            askLLaMA( { prompt: messageHistory, tokens: SETTINGS.defaultTokens }, ( result ) => {
                 sendOutput( result, txt => msg.channel.send( txt ) );
             } );
         } );
@@ -225,7 +225,7 @@ function handleMessage( msg ) {
             const twelveHoursAgo = Date.now() - 12 * 60 * 60 * 1000;
             getPastMessages( msg.channel, 5, twelveHoursAgo, messageHistory => {
                 askLLaMA( {
-                    prompt: messageHistory + "\n[Bot]",
+                    prompt: messageHistory,
                     tokens: SETTINGS.defaultTokens
                 }, ( result ) => {
                     sendOutput( result, txt => msg.channel.send( txt.split(/\r?\n/)[0] ) );
@@ -244,7 +244,7 @@ function handleMessage( msg ) {
                 const twelveHoursAgo = Date.now() - 12 * 60 * 60 * 1000;
                 getPastMessages( msg.channel, 5, twelveHoursAgo, messageHistory => {
                     askLLaMA( {
-                        prompt: messageHistory + "\n[Bot]",
+                        prompt: messageHistory,
                         tokens: SETTINGS.defaultTokens
                     }, ( result ) => {
                         sendOutput( result, txt => msg.channel.send( txt.split(/\r?\n/)[0] ) );
@@ -259,7 +259,7 @@ function handleMessage( msg ) {
             const twelveHoursAgo = Date.now() - 12 * 60 * 60 * 1000;
             getPastMessages( msg.channel, 5, twelveHoursAgo, messageHistory => {
                 askLLaMA( {
-                    prompt: messageHistory + "\n[Bot]",
+                    prompt: messageHistory,
                     tokens: SETTINGS.defaultTokens
                 }, ( result ) => {
                     sendOutput( result, txt => msg.channel.send( txt.split(/\r?\n/)[0] ) );

--- a/helperFunctions.js
+++ b/helperFunctions.js
@@ -16,8 +16,17 @@ function sendOutput( msg, send ) {
         return;
     }
 
-    // Trim leading/trailing whitespace to avoid blank sends
-    msg = msg.trim();
+    // If the model returned analysis/final markers, keep only the final output
+    const finalMarker = '<|start|>assistant<|channel|>final<|message|>';
+    const altFinalMarker = '<|assistant|>final<|message|>';
+    if ( msg.includes( finalMarker ) ) {
+        msg = msg.split( finalMarker ).pop();
+    } else if ( msg.includes( altFinalMarker ) ) {
+        msg = msg.split( altFinalMarker ).pop();
+    }
+
+    // Remove wrapping quotes and trim leading/trailing whitespace
+    msg = msg.replace( /^"|"$/g, '' ).trim();
 
     const LIMIT = 2000;
     const SEARCH_RANGE = 20; // characters to look back for a space

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -13,6 +13,13 @@ test('sendOutput splits long messages', () => {
   outputs.forEach(o => assert(o.length <= 2000));
 });
 
+test('sendOutput only returns final chunk after markers', () => {
+  const outputs = [];
+  const input = '<|channel|>analysis<|message|>blah<|start|>assistant<|channel|>final<|message|>hello"';
+  sendOutput(input, msg => outputs.push(msg));
+  assert.deepStrictEqual(outputs, ['hello']);
+});
+
 test('handleMessage ignores messages from bots', () => {
   const msg = { author: { bot: true } };
   const result = handleMessage(msg);


### PR DESCRIPTION
## Summary
- pass structured message history to `askLLaMA` instead of stringifying arrays
- strip analysis sections from model output so only final message is sent
- test that sendOutput drops analysis blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893cc65e5b8832fb9edae6aaaaf49a4