### PR TITLE
Handle missing permissions errors when sending messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 //load in settings from file
 const { SETTINGS } = require( './settings' );
-const { sendOutput, askLLaMA } = require( './helperFunctions' );
+const { sendOutput, askLLaMA, handleDiscordError } = require( './helperFunctions' );
 const { setNextInspirationalMessage, generateInspirationMessage } = require( './inspire' );
 const { sendWeatherReport } = require( './weather' );
 
@@ -96,7 +96,7 @@ function handleMessage( msg ) {
     }
 
     if ( msg.content === 'ping' ) {
-        msg.reply( 'pong' );
+        msg.reply( 'pong' ).catch( handleDiscordError );
         return;
     }
     if ( msg.content.toLowerCase().startsWith( "?llamaPersonality".toLowerCase() ) || msg.content.toLowerCase().startsWith( "?LP".toLowerCase() ) ) {
@@ -172,7 +172,7 @@ function handleMessage( msg ) {
                     randomResponseOn: SETTINGS.randomResponseOn,
                     responseRate: SETTINGS.responseRate,
                     qResponseRate: SETTINGS.qResponseRate
-                } ), null, 2 )
+                } ), null, 2 ).catch( handleDiscordError );
                 break;
             default:
                 msg.react( "👎" );

--- a/inspire.js
+++ b/inspire.js
@@ -5,7 +5,7 @@ module.exports = {
 
 const words = require( "./words(10000).json" );
 const axios = require( "axios" );
-const { askLLaMA, randomInt } = require( "./helperFunctions" );
+const { askLLaMA, randomInt, handleDiscordError } = require( "./helperFunctions" );
 
 async function generateInspirationMessage( channel, scheduleNext, forceSend = false ) {
     if ( randomInt( 0, 100 ) > 25 && !forceSend ) {
@@ -47,7 +47,7 @@ async function generateInspirationMessage( channel, scheduleNext, forceSend = fa
         crazy: true
     }, async ( res ) => {
         const msg = msgRegEx.exec( res )?.[1] ?? res;
-        channel.send( { content: msg } );
+        Promise.resolve( channel.send( { content: msg } ) ).catch( handleDiscordError );
     } );
 
     if ( scheduleNext ) {

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -46,7 +46,7 @@ test('handleMessage responds to ?llamaOptions list', () => {
     guild: {},
     content: '?llamaOptions list',
     react: () => {},
-    reply: text => replies.push(text)
+    reply: text => { replies.push(text); return { catch: () => {} }; }
   };
   handleMessage(msg);
   assert.strictEqual(replies.length, 1);

--- a/tests/helperFunctions.test.js
+++ b/tests/helperFunctions.test.js
@@ -20,6 +20,18 @@ test('sendOutput ignores blank messages', () => {
   assert.deepStrictEqual(sent, []);
 });
 
+test('sendOutput catches send errors', async () => {
+  const errors = [];
+  const orig = console.error;
+  console.error = e => errors.push(e);
+  await new Promise(resolve => {
+    sendOutput('hi', () => Promise.reject({ code: 50013 }));
+    setImmediate(resolve);
+  });
+  console.error = orig;
+  assert.ok(errors.some(e => typeof e === 'string' && e.includes('Missing Permissions')));
+});
+
 // askLLaMA tests
 
 test('askLLaMA posts string prompt and returns text', async () => {

--- a/weather.js
+++ b/weather.js
@@ -1,5 +1,5 @@
 const axios = require( "axios" );
-const { askLLaMA } = require( "./helperFunctions" );
+const { askLLaMA, handleDiscordError } = require( "./helperFunctions" );
 module.exports = {
     sendWeatherReport
 }
@@ -35,6 +35,6 @@ ${ question }`;
 
     const prompt = await getPrompt();
     askLLaMA( { prompt, tokens: 200 }, msg => {
-        channel.send( { content: msg } );
+        Promise.resolve( channel.send( { content: msg } ) ).catch( handleDiscordError );
     } );
 }


### PR DESCRIPTION
## Summary
- Guard all outgoing Discord messages with a shared `handleDiscordError` helper to log and swallow permission errors
- Wrap direct `reply` calls and weather/inspiration send operations to avoid unhandled rejections
- Add test ensuring `sendOutput` catches failed send attempts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893d94f97f8832fad9c8b4c23cf9bae